### PR TITLE
Added basic itest framework with travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python: 2.7
+sudo: true
+install:
+  - pip install tox
+script:
+  - ./itests/install-chronos.sh
+  - ./itests/start-chronos.sh
+  - make itests

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: itests
+itests:
+	tox -e itests

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 chronos-python
 ==============
 
+[![Build Status](https://travis-ci.org/asher/chronos-python.svg?branch=master)](https://travis-ci.org/asher/chronos-python)
+
 Simple python api for the chronos job scheduler
 
 ###Installation

--- a/itests/chronos-python.feature
+++ b/itests/chronos-python.feature
@@ -1,0 +1,6 @@
+Feature: chronos-python can interact with chronos
+
+  Scenario: Trivial chronos interaction
+    Given a working chronos instance
+    When we create a trivial chronos job
+    Then we should be able to see it when we list jobs

--- a/itests/environment.py
+++ b/itests/environment.py
@@ -1,0 +1,13 @@
+import time
+
+
+def after_scenario(context, scenario):
+    """If a chronos client object exists in our context, delete any jobs before the next scenario."""
+    if context.client:
+        while True:
+            jobs = context.client.list()
+            if not jobs:
+                break
+            for job in jobs:
+                context.client.delete(job['name'])
+            time.sleep(0.5)

--- a/itests/install-chronos.sh
+++ b/itests/install-chronos.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+CHRONOSVERSION=2.3.4
+
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
+DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
+CODENAME=$(lsb_release -cs)
+
+# Add the repository
+echo "deb http://repos.mesosphere.com/${DISTRO} ${CODENAME} main" | 
+  sudo tee /etc/apt/sources.list.d/mesosphere.list
+
+sudo apt-get -qq update
+
+sudo apt-get -y --force-yes install mesos chronos=$CHRONOSVERSION*

--- a/itests/start-chronos.sh
+++ b/itests/start-chronos.sh
@@ -1,0 +1,4 @@
+sudo /etc/init.d/zookeeper start
+sleep 5
+sudo /etc/init.d/chronos start
+sleep 5

--- a/itests/steps/chronos_steps.py
+++ b/itests/steps/chronos_steps.py
@@ -1,0 +1,32 @@
+import sys
+
+from behave import given, when, then
+
+import chronos
+
+
+@given('a working chronos instance')
+def working_chronos(context):
+    if not hasattr(context, 'client'):
+        context.client = chronos.connect('localhost:4400')
+
+
+@when(u'we create a trivial chronos job')
+def create_trivial_chronos_job(context):
+    job = {
+        'async': False,
+        'command': 'echo 1',
+        'epsilon': 'PT15M',
+        'name': 'test_chronos_job',
+        'owner': '',
+        'disabled': True,
+        'schedule': 'R/2014-01-01T00:00:00Z/PT60M',
+    }
+    context.client.add(job)
+
+
+@then(u'we should be able to see it when we list jobs')
+def list_chronos_jobs_has_trivial_job(context):
+    jobs = context.client.list()
+    job_names = [ job['name'] for job in jobs ]
+    assert 'test_chronos_job' in job_names

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+httplib2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+passenv = TRAVIS
+usedevelop=True
+basepython = python2.7
+envlist = py
+
+[testenv:itests]
+passenv = TRAVIS
+basepython = python2.7
+whitelist_externals=/bin/bash
+skipsdist=True
+changedir=itests/
+deps =
+    -rrequirements.txt
+    behave
+    mock
+commands =
+    behave {posargs}


### PR DESCRIPTION
I would like to start making PRs to this repo, but I have no way to be sure that they work.

This adds travis integration so that we can test against different python/chronos versions, and have confidence that the python bindings match up with reality.

If accepted, please enable travis integration at https://travis-ci.org/profile/asher so that the badge and PR hooks are activated.
