### PR TITLE
Allow a list of servers to be passed in to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Simple python api for the chronos job scheduler
 ```
 import chronos
 c = chronos.connect("chronos.mesos.server.com:8080")
+# or specify multilple servers that will be tried in order
+c = chronos.connect(["chronos1.mesos.server.com:8080", "chronos2.mesos.server.com:8080"])
 
 # get list of scheduled jobs and their status as
 # [{ 'name': 'job1', ..}, { 'name': 'job2', ..}]

--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -27,6 +27,14 @@ import json
 import logging
 
 
+class ChronosAPIException(Exception):
+    pass
+
+
+class MissingFieldException(Exception):
+    pass
+
+
 class ChronosClient(object):
     _user = None
     _password = None
@@ -101,18 +109,18 @@ class ChronosClient(object):
                 payload = content
 
         if payload is None and status != 204:
-            raise Exception("HTTP Error %d occurred." % status)
+            raise ChronosAPIException("Request to Chronos API failed: status: %d, response: %s" % (status, content))
 
         return payload
 
     def _check_fields(self, job):
         for k in ChronosJob.fields:
             if k not in job:
-                raise Exception("missing required field %s" % k)
+                raise MissingFieldException("missing required field %s" % k)
         for k in ChronosJob.one_of:
             if k in job:
                 return True
-        raise Exception("Job must include one of %s" % ChronosJob.one_of)
+        raise MissingFieldException("Job must include one of %s" % ChronosJob.one_of)
 
 
 class ChronosJob(object):

--- a/itests/itest_utils.py
+++ b/itests/itest_utils.py
@@ -2,8 +2,6 @@ import errno
 from functools import wraps
 import os
 import signal
-import sys
-import threading
 import time
 
 import requests

--- a/tests/test_chronos_init.py
+++ b/tests/test_chronos_init.py
@@ -1,6 +1,8 @@
 import json
 
 import mock
+import pytest
+import httplib2
 
 import chronos
 
@@ -21,3 +23,28 @@ def test_check_returns_raw_response_when_not_json():
     fake_content = 'UNAUTHORIZED'
     actual = client._check(fake_response, fake_content)
     assert actual == fake_content
+
+
+def test_api_error_throws_exception():
+    client = chronos.ChronosClient(hostname="localhost")
+    mock_response = mock.Mock()
+    mock_response.status = 500
+    mock_request = mock.Mock(return_value=(mock_response, None))
+    with mock.patch.object(httplib2.Http, 'request', mock_request):
+        with pytest.raises(chronos.ChronosAPIException):
+            client.list()
+
+
+def test_check_missing_fields():
+    client = chronos.ChronosClient(hostname="localhost")
+    for field in chronos.ChronosJob.fields:
+        without_field = {x: 'foo' for x in filter(lambda y: y != field, chronos.ChronosJob.fields)}
+        with pytest.raises(chronos.MissingFieldException):
+            client._check_fields(without_field)
+
+
+def test_check_one_of():
+    client = chronos.ChronosClient(hostname="localhost")
+    job = {field: 'foo' for field in chronos.ChronosJob.fields}
+    with pytest.raises(chronos.MissingFieldException):
+        client._check_fields(job)

--- a/tests/test_chronos_init.py
+++ b/tests/test_chronos_init.py
@@ -35,3 +35,14 @@ def test_check_returns_raw_response_when_not_json():
     fake_content = 'UNAUTHORIZED'
     actual = client._check(fake_response, fake_content)
     assert actual == fake_content
+
+
+def test_uses_server_list():
+    client = chronos.ChronosClient(["host1", "host2", "host3"], proto="http")
+    good_request = (mock.Mock(status=204), '')
+    bad_request = (mock.Mock(status=500), '')
+
+    conn_mock = mock.Mock(request=mock.Mock(side_effect=[bad_request, good_request, bad_request]))
+    with mock.patch('httplib2.Http', return_value=conn_mock):
+        client._call('/fake_url')
+        assert conn_mock.request.call_count == 2

--- a/tests/test_chronos_init.py
+++ b/tests/test_chronos_init.py
@@ -1,12 +1,26 @@
 import json
-
 import mock
 
 import chronos
 
 
+def test_connect_accepts_single_host():
+    client = chronos.ChronosClient("localhost", proto="http")
+    assert client.servers == ['http://localhost']
+
+
+def test_connect_accepts_list_of_hosts():
+    client = chronos.ChronosClient(["host1", "host2"], proto="http")
+    assert client.servers == ['http://host1', 'http://host2']
+
+
+def test_connect_accepts_proto():
+    client = chronos.ChronosClient("localhost", proto="fake_proto")
+    assert client.servers == ['fake_proto://localhost']
+
+
 def test_check_accepts_json():
-    client = chronos.ChronosClient(hostname="localhost")
+    client = chronos.ChronosClient("localhost")
     fake_response = mock.Mock()
     fake_response.status = 200
     fake_content = '{ "foo": "bar" }'
@@ -15,7 +29,7 @@ def test_check_accepts_json():
 
 
 def test_check_returns_raw_response_when_not_json():
-    client = chronos.ChronosClient(hostname="localhost")
+    client = chronos.ChronosClient("localhost")
     fake_response = mock.Mock()
     fake_response.status = 401
     fake_content = 'UNAUTHORIZED'


### PR DESCRIPTION
Adds support to pass in a list of Chronos servers that will be tried in order (to mimic the marathon-python client). Also adds some custom exception classes so that it's easier to try-catch specific things.

Also fixes issue #2.
