### PR TITLE
Deal with chronos jobs that have spaces in the name

### DIFF
--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -25,6 +25,7 @@
 import httplib2
 import json
 import logging
+from urllib import quote
 
 
 class ChronosClient(object):
@@ -85,7 +86,7 @@ class ChronosClient(object):
         conn = httplib2.Http(disable_ssl_certificate_validation=True)
         if self._user and self._password:
             conn.add_credentials(self._user, self._password)
-        endpoint = "%s%s" % (self.baseurl, url)
+        endpoint = "%s%s" % (self.baseurl, quote(url))
         self.logger.debug(endpoint)
         return self._check(*conn.request(endpoint, method, body=body, headers=hdrs))
 

--- a/itests/chronos-python.feature
+++ b/itests/chronos-python.feature
@@ -4,3 +4,10 @@ Feature: chronos-python can interact with chronos
     Given a working chronos instance
     When we create a trivial chronos job
     Then we should be able to see it when we list jobs
+
+  Scenario: Handling spaces in job names
+    Given a working chronos instance
+     When we create a chronos job with spaces
+     Then we should be able to see the job with spaces when we list jobs
+      And we should be able to delete it
+      And we should not be able to see it when we list jobs

--- a/itests/steps/chronos_steps.py
+++ b/itests/steps/chronos_steps.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 
 import chronos
 from behave import given, when, then
@@ -6,6 +7,10 @@ from behave import given, when, then
 from itest_utils import get_chronos_connection_string
 
 sys.path.append('../')
+
+log = logging.getLogger('chronos')
+log.addHandler(logging.StreamHandler(sys.stdout))
+log.setLevel(logging.DEBUG)
 
 
 @given('a working chronos instance')
@@ -36,3 +41,34 @@ def list_chronos_jobs_has_trivial_job(context):
     jobs = context.client.list()
     job_names = [job['name'] for job in jobs]
     assert 'test_chronos_job' in job_names
+
+
+@when(u'we create a chronos job with spaces')
+def create_job_with_spaces(context):
+    job = {
+        'async': False,
+        'command': 'echo 1',
+        'epsilon': 'PT15M',
+        'name': 'test chronos job with spaces',
+        'owner': '',
+        'disabled': True,
+        'schedule': 'R/2014-01-01T00:00:00Z/PT60M',
+    }
+    context.client.add(job)
+
+@then(u'we should be able to see the job with spaces when we list jobs')
+def list_chronos_jobs_has_trivial_job(context):
+    jobs = context.client.list()
+    job_names = [job['name'] for job in jobs]
+    assert 'test chronos job with spaces' in job_names
+
+@then(u'we should be able to delete it')
+def delete_job_with_spaces(context):
+    context.client.delete("test chronos job with spaces")
+
+
+@then(u'we should not be able to see it when we list jobs')
+def not_see_job_with_spaces(context):
+    jobs = context.client.list()
+    job_names = [job['name'] for job in jobs]
+    assert "test chronos job with spaces" not in job_names


### PR DESCRIPTION
This patch correctly will quote the URL when we interact with the chronos api, so it properly deals with characters like spaces in chronos job names (which are perfectly valid chronos job names).

This is analogous to how the actual web interface works when you click the new job button.
