### PR TITLE
add /job/stat/{job_name} and /scheduler/stats/* endpoints

### DIFF
--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -84,6 +84,28 @@ class ChronosClient(object):
         """Update an existing job by name"""
         return self.add(job_def, update=True)
 
+    def job_stat(self, name):
+        """ List stats for a job """
+        return self._call('/scheduler/job/stat/%s' % name, "GET")
+
+    def scheduler_stat_99th(self):
+        return self._call('/scheduler/stats/99thPercentile', 'GET')
+
+    def scheduler_stat_98th(self):
+        return self._call('/scheduler/stats/98thPercentile', 'GET')
+
+    def scheduler_stat_95th(self):
+        return self._call('/scheduler/stats/95thPercentile', 'GET')
+
+    def scheduler_stat_75th(self):
+        return self._call('/scheduler/stats/75thPercentile', 'GET')
+
+    def scheduler_stat_median(self):
+        return self._call('/scheduler/stats/median', 'GET')
+
+    def scheduler_stat_mean(self):
+        return self._call('/scheduler/stats/mean', 'GET')
+
     def _call(self, url, method="GET", body=None, headers={}):
         hdrs = {}
         if body:

--- a/itests/chronos-python.feature
+++ b/itests/chronos-python.feature
@@ -2,12 +2,20 @@ Feature: chronos-python can interact with chronos
 
   Scenario: Trivial chronos interaction
     Given a working chronos instance
-    When we create a trivial chronos job
-    Then we should be able to see it when we list jobs
+    When we create a trivial chronos job named "myjob"
+    Then we should be able to see the job named "myjob" when we list jobs
 
   Scenario: Handling spaces in job names
     Given a working chronos instance
-     When we create a chronos job with spaces
-     Then we should be able to see the job with spaces when we list jobs
-      And we should be able to delete it
-      And we should not be able to see it when we list jobs
+     When we create a trivial chronos job named "job with spaces"
+     Then we should be able to see the job named "job with spaces" when we list jobs
+      And we should be able to delete the job named "job with spaces"
+      And we should not be able to see the job named "job with spaces" when we list jobs
+
+  Scenario: Gathering job stats for job
+    Given  a working chronos instance
+    When we create a trivial chronos job named "myjob"
+    Then we should be able to see timings for the job named "myjob" when we look at scheduler stats
+    And we should be able to see percentiles for all jobs
+    And we should be able to see the median timing for all jobs
+    And we should be able to see the mean timing for all jobs

--- a/itests/steps/chronos_steps.py
+++ b/itests/steps/chronos_steps.py
@@ -1,6 +1,5 @@
 import sys
 import logging
-
 import chronos
 from behave import given, when, then
 
@@ -22,53 +21,72 @@ def working_chronos(context):
         context.client = chronos.connect(chronos_connection_string)
 
 
-@when(u'we create a trivial chronos job')
-def create_trivial_chronos_job(context):
+@when(u'we create a trivial chronos job named "{job_name}"')
+def create_trivial_chronos_job(context, job_name):
     job = {
         'async': False,
         'command': 'echo 1',
-        'epsilon': 'PT15M',
-        'name': 'test_chronos_job',
+        'epsilon': 'PT1M',
+        'name': job_name,
         'owner': '',
-        'disabled': True,
+        'disabled': False,
         'schedule': 'R/2014-01-01T00:00:00Z/PT60M',
     }
     context.client.add(job)
 
 
-@then(u'we should be able to see it when we list jobs')
-def list_chronos_jobs_has_trivial_job(context):
+@then(u'we should be able to see the job named "{job_name}" when we list jobs')
+def list_chronos_jobs_has_trivial_job(context, job_name):
     jobs = context.client.list()
     job_names = [job['name'] for job in jobs]
-    assert 'test_chronos_job' in job_names
+    assert job_name in job_names
 
 
-@when(u'we create a chronos job with spaces')
-def create_job_with_spaces(context):
-    job = {
-        'async': False,
-        'command': 'echo 1',
-        'epsilon': 'PT15M',
-        'name': 'test chronos job with spaces',
-        'owner': '',
-        'disabled': True,
-        'schedule': 'R/2014-01-01T00:00:00Z/PT60M',
+@then(u'we should be able to delete the job named "{job_name}"')
+def delete_job_with_spaces(context, job_name):
+    context.client.delete(job_name)
+
+
+@then(u'we should not be able to see the job named "{job_name}" when we list jobs')
+def not_see_job_with_spaces(context, job_name):
+    jobs = context.client.list()
+    job_names = [job['name'] for job in jobs]
+    assert 'test chronos job with spaces' not in job_names
+
+
+@then(u'we should be able to see timings for the job named "{job_name}" when we look at scheduler stats')
+def check_job_has_timings(context, job_name):
+    stats = context.client.job_stat(job_name)
+    assert stats == {'histogram': {
+        'median': 0.0,
+        '98thPercentile': 0.0,
+        '75thPercentile': 0.0,
+        '95thPercentile': 0.0,
+        '99thPercentile': 0.0,
+        'count': 0,
+        'mean': 0.0,
+        },
+        'taskStatHistory': []
     }
-    context.client.add(job)
-
-@then(u'we should be able to see the job with spaces when we list jobs')
-def list_chronos_jobs_has_trivial_job(context):
-    jobs = context.client.list()
-    job_names = [job['name'] for job in jobs]
-    assert 'test chronos job with spaces' in job_names
-
-@then(u'we should be able to delete it')
-def delete_job_with_spaces(context):
-    context.client.delete("test chronos job with spaces")
 
 
-@then(u'we should not be able to see it when we list jobs')
-def not_see_job_with_spaces(context):
-    jobs = context.client.list()
-    job_names = [job['name'] for job in jobs]
-    assert "test chronos job with spaces" not in job_names
+@then(u'we should be able to see percentiles for all jobs')
+def check_percentiles(context):
+    ninety_ninth = context.client.scheduler_stat_99th()
+    ninety_eighth = context.client.scheduler_stat_98th()
+    ninety_fifth = context.client.scheduler_stat_95th()
+    seventy_fifth = context.client.scheduler_stat_75th()
+    for percentile in ninety_ninth, ninety_eighth, ninety_fifth, seventy_fifth:
+        assert percentile == [{'jobNameLabel': 'myjob', 'time': 0.0}]
+
+
+@then(u'we should be able to see the median timing for all jobs')
+def check_median(context):
+    medians = context.client.scheduler_stat_median()
+    assert medians == [{'jobNameLabel': 'myjob', 'time': 0.0}]
+
+
+@then(u'we should be able to see the mean timing for all jobs')
+def check_mode(context):
+    modes = context.client.scheduler_stat_median()
+    assert modes == [{'jobNameLabel': 'myjob', 'time': 0.0}]


### PR DESCRIPTION
These are undocumented, but we can still expose them with the client.

They're used in the chronos web ui to show stats, so it's safe to assume these endpoints are supported (even if they're not documented).

Code hint for the job stats pattern [here](https://github.com/mesos/chronos/blob/master/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala#L16) and [here](https://github.com/mesos/chronos/blob/master/src/main/scala/org/apache/mesos/chronos/scheduler/api/JobManagementResource.scala#L120).
Code hint for the scheduler stats endpoint [here](https://github.com/mesos/chronos/blob/master/src/main/scala/org/apache/mesos/chronos/scheduler/api/PathConstants.scala#L15) and [here](https://github.com/mesos/chronos/blob/master/src/main/scala/org/apache/mesos/chronos/scheduler/api/StatsResource.scala#L43).

I've also done some minor refactoring of the itests.
