### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 env:
- - CHRONOSVERSION: 2.3.4
  - CHRONOSVERSION: 2.4.0
 
 language: python
@@ -7,7 +6,6 @@ python:
   - 2.7
   - 3.5
 sudo: true
-dist: trusty
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ env:
  - CHRONOSVERSION: 2.4.0
 
 language: python
-python: 2.7
+python:
+  - 2.7
+  - 3.5
 sudo: true
+dist: trusty
 install:
   - pip install tox
 script:

--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -156,13 +156,10 @@ class ChronosClient(object):
 
         if content:
             try:
-                payload = json.loads(content)
-            except (TypeError, ValueError):
-                try:
-                    payload = json.loads(content.decode('utf-8'))
-                except ValueError:
-                    self.logger.error("Response not valid in json: %s" % content)
-                    payload = content
+                payload = json.loads(content.decode('utf-8'))
+            except ValueError:
+                self.logger.error("Response not valid json: %s" % content)
+                payload = content
 
         if payload is None and status != 204:
             raise ChronosAPIError("Request to Chronos API failed: status: %d, response: %s" % (status, content))

--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -25,7 +25,12 @@
 import httplib2
 import json
 import logging
-from urllib import quote
+
+# Python 3 changed the submodule for quote
+try:
+    from urllib import quote
+except ImportError:
+    from urllib.parse import quote
 
 
 class ChronosAPIError(Exception):
@@ -152,9 +157,12 @@ class ChronosClient(object):
         if content:
             try:
                 payload = json.loads(content)
-            except ValueError:
-                self.logger.error("Response not valid json: %s" % content)
-                payload = content
+            except (TypeError, ValueError):
+                try:
+                    payload = json.loads(content.decode('utf-8'))
+                except ValueError:
+                    self.logger.error("Response not valid in json: %s" % content)
+                    payload = content
 
         if payload is None and status != 204:
             raise ChronosAPIError("Request to Chronos API failed: status: %d, response: %s" % (status, content))

--- a/itests/install-chronos.sh
+++ b/itests/install-chronos.sh
@@ -3,7 +3,7 @@ set -e
 
 # Default version of chronos to test against if not set by the user
 [[ -f /root/chronos-version ]] && source /root/chronos-version
-CHRONOSVERSION="${CHRONOSVERSION:-2.3.4}"
+CHRONOSVERSION="${CHRONOSVERSION:-2.4.0}"
 
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
 DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
# Support for python 3 and removed chronos legacy version
## Change default chronos version
- Mesosphere removed chronos version 2.3.4 for ubuntu 12.04.
- Tested with chronos 2.4.0 and ubuntu 12.04
## Python 3 support
- Added the python version 3.5 in Travis configuration.
