### PR TITLE
epsilon is not required field of job definition

### DIFF
--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -201,7 +201,6 @@ class ChronosJob(object):
     fields = [
         "async",
         "command",
-        "epsilon",
         "name",
         "owner",
         "disabled"

--- a/tests/test_chronos_init.py
+++ b/tests/test_chronos_init.py
@@ -96,7 +96,6 @@ def test_check_missing_container_fields():
             "container": container_without_field,
             "async": False,
             "command": "while sleep 10; do date =u %T; done",
-            "epsilon": "PT15M",
             "schedule": "R/2014-09-25T17:22:00Z/PT2M",
             "name": "dockerjob",
             "owner": "test",


### PR DESCRIPTION
Please, look at https://mesos.github.io/chronos/docs/api.html "Job Configuration" section. Chronos uses `--task_epsilon` flag as default if `epsilon` doesnt defined in job definition. In fact chronos-python now forces fill up `epsilon` field and doesnt permit use this "fallback to default" logic.