### PR TITLE
Generalize auth token

### DIFF
--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -54,9 +54,10 @@ class ChronosClient(object):
     _user = None
     _password = None
 
-    def __init__(self, servers, proto="http", username=None, password=None, level='WARN'):
+    def __init__(self, servers, proto="http", username=None, password=None, extra_headers=None, level='WARN'):
         server_list = servers if isinstance(servers, list) else [servers]
         self.servers = ["%s://%s" % (proto, server) for server in server_list]
+        self.extra_headers = extra_headers
         if username and password:
             self._user = username
             self._password = password
@@ -137,6 +138,8 @@ class ChronosClient(object):
         conn = httplib2.Http(disable_ssl_certificate_validation=True)
         if self._user and self._password:
             conn.add_credentials(self._user, self._password)
+        if self.extra_headers:
+            hdrs.update(self.extra_headers)
 
         response = None
         servers = list(self.servers)
@@ -202,5 +205,5 @@ class ChronosJob(object):
     one_of = ["schedule", "parents"]
 
 
-def connect(servers, proto="http", username=None, password=None):
-    return ChronosClient(servers, proto=proto, username=username, password=password)
+def connect(servers, proto="http", username=None, password=None, extra_headers=None):
+    return ChronosClient(servers, proto=proto, username=username, password=password, extra_headers=extra_headers)


### PR DESCRIPTION
These contains the improvements that were asked for in [cantenesse's pr](https://github.com/asher/chronos-python/pull/29). I was unable to figure out how to add a test case though, however I tested this throughly locally (adding a token to auth, adding a bad token, ensuring headers persist with the object.)