### PR TITLE
Don't configure global logging settings on client initialization

### DIFF
--- a/bin/chronos-nagios.py
+++ b/bin/chronos-nagios.py
@@ -24,6 +24,7 @@
 import sys
 import re
 import argparse
+import logging
 import chronos
 
 
@@ -95,4 +96,5 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s', level="WARN")
     main()

--- a/bin/chronos-sync-jobs.py
+++ b/bin/chronos-sync-jobs.py
@@ -26,6 +26,7 @@ import sys
 import re
 import argparse
 import json
+import logging
 import chronos
 
 
@@ -140,4 +141,5 @@ def main():
 
 
 if __name__ == "__main__":
+    logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s', level="WARN")
     main()

--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -66,9 +66,9 @@ class ChronosClient(object):
     _password = None
 
     def __init__(
-        self, servers, proto="http", username=None,
-        password=None, extra_headers=None, level='WARN',
-        scheduler_api_version='v1', validate_ssl_certificates=True,
+        self, servers, proto="http", username=None, password=None,
+        extra_headers=None, scheduler_api_version='v1',
+        validate_ssl_certificates=True,
     ):
         server_list = servers if isinstance(servers, list) else [servers]
         self.servers = ["%s://%s" % (proto, server) for server in server_list]
@@ -76,7 +76,6 @@ class ChronosClient(object):
         if username and password:
             self._user = username
             self._password = password
-        logging.basicConfig(format='%(asctime)s %(levelname)-8s %(message)s', level=level)
         self.logger = logging.getLogger(__name__)
         if scheduler_api_version is None:
             warnings.warn("Chronos >=3.x requires scheduler_api_version set", FutureWarning)


### PR DESCRIPTION
This PR removes the call to `logging.basicConfig` in the client's `__init__` method. I found it surprising that initializing the client had such global side-effects.

The [official documentation suggests](https://docs.python.org/3/library/logging.html#logging.basicConfig) that this function should be called once from the main thread at program startup, this call as it is makes that difficult to achieve when initialising clients in background threads.