### PR TITLE
Fix python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,20 @@
 language: python
-matrix:
-  include:
-  - os: linux
-    sudo: required
-    services: docker
-    python: 2.7
-    env: CHRONOSVERSION=2.4.0
-  - os: linux
-    sudo: required
-    services: docker
-    python: 3.5
-    env: CHRONOSVERSION=2.4.0
-  - os: linux
-    sudo: required
-    services: docker
-    python: 2.7
-    env: CHRONOSVERSION=3.0.2
-  - os: linux
-    sudo: required
-    services: docker
-    python: 3.5
-    env: CHRONOSVERSION=3.0.2
+cache: pip
+os: linux
+sudo: required
+env:
+  - TOXENV=py27
+  - TOXENV=py36
+  - TOXENV=itests CHRONOSVERSION=2.4.0
+  - TOXENV=itests CHRONOSVERSION=3.0.2
+  - TOXENV=itests-py3 CHRONOSVERSION=2.4.0
+  - TOXENV=itests-py3 CHRONOSVERSION=3.0.2
+services:
+  - docker
 before_install:
   - docker-compose -f itests/docker-compose.yml pull
-install:
-  - pip install tox
-script:
-  - make test && make itests
+install: pip install tox
+script: tox -i https://pypi.python.org/simple
 
 deploy:
   - provider: pypi

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,4 @@ test:
 .PHONY: itests
 itests:
 	tox -e itests
+	tox -e itests-py3

--- a/bin/chronos-nagios.py
+++ b/bin/chronos-nagios.py
@@ -20,6 +20,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+from __future__ import print_function
 
 import sys
 import re
@@ -57,7 +58,7 @@ def main():
     cjobs = c.list()
 
     if not isinstance(cjobs, list):
-        print "UNKNOWN: error querying chronos"
+        print("UNKNOWN: error querying chronos")
         sys.exit(3)
 
     for job in cjobs:
@@ -85,13 +86,13 @@ def main():
         umsg = ''
 
     if len(fails) == 0:
-        print "OK: %d jobs succeeded on last run %s" % (len(ok), umsg)
+        print("OK: %d jobs succeeded on last run %s" % (len(ok), umsg))
         sys.exit(0)
     elif len(fails) >= int(args.crit):
-        print "CRITICAL: %d failed jobs: %s %s" % (len(fails), str(fails).strip('[]'), umsg)
+        print("CRITICAL: %d failed jobs: %s %s" % (len(fails), str(fails).strip('[]'), umsg))
         sys.exit(2)
     elif len(fails) >= int(args.warn):
-        print "WARNING: %d failed jobs: %s %s" % (len(fails), str(fails).strip('[]'), umsg)
+        print("WARNING: %d failed jobs: %s %s" % (len(fails), str(fails).strip('[]'), umsg))
         sys.exit(1)
 
 

--- a/bin/chronos-sync-jobs.py
+++ b/bin/chronos-sync-jobs.py
@@ -20,6 +20,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+from __future__ import print_function
 
 import os
 import sys
@@ -37,7 +38,7 @@ def read_job_file(path):
         if "name" in job:
             return job
     except:
-        print "Error: failed to decode %s" % path
+        print("Error: failed to decode %s" % path)
 
 
 def find_json_files(path):
@@ -80,7 +81,7 @@ def main():
 
     if args.list:
         # cjobs isn't json but this still gets us the pretty
-        print json.dumps(cjobs, sort_keys=True, indent=4)
+        print(json.dumps(cjobs, sort_keys=True, indent=4))
         sys.exit(0)
 
     if args.sync:
@@ -96,21 +97,23 @@ def main():
         for file in job_files:
             job = read_job_file(file)
             if not job:
-                print "Skipping %s" % file
+                print("Skipping %s" % file)
             else:
                 if job['name'] in jobs:
                     if check_update(jobs, job):
-                        print "Updating job %s from file %s" % (job['name'], file)
+                        print("Updating job %s from file %s" % (job['name'], file))
                         if not args.n:
                             try:
                                 c.update(job)
                             except:
                                 retry['update'].append(job)
                     else:
-                        print "Job %s defined in %s is up-to-date on Chronos" \
+                        print(
+                            "Job %s defined in %s is up-to-date on Chronos"
                             % (job['name'], file)
+                        )
                 else:
-                    print "Adding job %s from file %s" % (job['name'], file)
+                    print("Adding job %s from file %s" % (job['name'], file))
                     if not args.n:
                         try:
                             c.add(job)
@@ -123,7 +126,7 @@ def main():
             if len(retry['update']) > 0:
                 job = retry['update'].pop(0)
                 try:
-                    print "Retry %d for job %s" % (attempt, job['name'])
+                    print("Retry %d for job %s" % (attempt, job['name']))
                     c.update(job)
                 except:
                     retry['update'].append(job)
@@ -131,13 +134,13 @@ def main():
             if len(retry['add']) > 0:
                 job = retry['add'].pop(0)
                 try:
-                    print "Retry %d for job %s" % (attempt, job['name'])
+                    print("Retry %d for job %s" % (attempt, job['name']))
                     c.add(job)
                 except:
                     retry['add'].append(job)
 
         if len(retry['update']) > 0 or len(retry['add']) > 0:
-            print "Failed Jobs: %s" % sorted((retry['update'] + retry['add']))
+            print("Failed Jobs: %s" % sorted((retry['update'] + retry['add'])))
 
 
 if __name__ == "__main__":

--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -203,13 +203,13 @@ class ChronosClient(object):
                 self.logger.debug("Fetch %s %s" % (endpoint, method, ))
                 resp, content = conn.request(endpoint, method, body=body, headers=hdrs)
             except (socket.error, httplib2.ServerNotFoundError) as e:
-                self.logger.error('Error while calling %s: %s. Retrying', endpoint, e.message)
+                self.logger.error('Error while calling %s: %s. Retrying', endpoint, str(e))
                 continue
             try:
                 response = self._check(resp, content)
                 return response
             except ChronosAPIError as e:
-                self.logger.error('Error while calling %s: %s', endpoint, e.message)
+                self.logger.error('Error while calling %s: %s', endpoint, str(e))
 
         raise ChronosAPIError('No remaining Chronos servers to try')
 
@@ -227,7 +227,7 @@ class ChronosClient(object):
             except ValueError:
                 if resp['content-type'] == "application/json":
                     self.logger.error("Response not valid json: %s" % content)
-                payload = content
+                payload = content.decode('utf-8')
 
         if payload is None and status != 204:
             raise ChronosAPIError("Request to Chronos API failed: status: %d, response: %s" % (status, content))

--- a/itests/itest_utils.py
+++ b/itests/itest_utils.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from __future__ import print_function
+
 import errno
 import os
 import signal
@@ -37,7 +39,7 @@ def wait_for_chronos():
     # we start chronos always on port 4400
     chronos_service = 'localhost:4400'
     while True:
-        print 'Connecting to chronos on %s' % chronos_service
+        print('Connecting to chronos on %s' % chronos_service)
         try:
             response = requests.get('http://%s/ping' % chronos_service, timeout=2)
         except (
@@ -47,5 +49,5 @@ def wait_for_chronos():
             time.sleep(2)
             continue
         if response.status_code == 200:
-            print "Chronos is up and running!"
+            print("Chronos is up and running!")
             break

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(
         "Development Status :: 3 - Alpha",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
     ],
     install_requires=[
         'httplib2 >= 0.9'

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,11 @@
 [tox]
 usedevelop=True
-basepython = python2.7
-envlist = py
-
+envlist = py27, py36
 
 [flake8]
 max-line-length = 120
 
-
-[testenv:py]
-basepython = python2.7
+[testenv]
 deps =
     -rtest-requirements.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,22 @@ commands =
     flake8 bin chronos itests tests setup.py
     py.test -v {posargs:tests}
 
-
 [testenv:itests]
 passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
 basepython = python2.7
+whitelist_externals=/bin/bash
+skipsdist=True
+changedir=itests/
+deps =
+    -rtest-requirements.txt
+commands =
+    /bin/bash -c "docker-compose up -d chronos-{env:CHRONOSVERSION:3.0.2}"
+    behave --tags all,{env:CHRONOSVERSION:3.0.2} --no-capture --no-capture-stderr -Dchronos_version={env:CHRONOSVERSION:3.0.2} {posargs}
+    /bin/bash -c "docker-compose down"
+
+[testenv:itests-py3]
+passenv = DOCKER_TLS_VERIFY DOCKER_HOST DOCKER_CERT_PATH
+basepython = python3
 whitelist_externals=/bin/bash
 skipsdist=True
 changedir=itests/


### PR DESCRIPTION
Sets this package up for python3 compatibility:

Some changes:
* Actually test with py3
* Respect that httplib gives you str headers but bytes as the body, in our case that means lots of encode and decode
* Change the travis file to be a bit more compact
* Change exceptions to not use the deprecated (since 2.6) Exception.message and instead just str it