### PR TITLE
Don't warn on None scheduler_api_version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: "3.6"
 cache: pip
 os: linux
 sudo: required

--- a/chronos/__init__.py
+++ b/chronos/__init__.py
@@ -26,7 +26,6 @@ import httplib2
 import socket
 import json
 import logging
-import warnings
 
 # Python 3 changed the submodule for quote
 try:
@@ -84,11 +83,10 @@ class ChronosClient(object):
             self._password = password
         self.logger = logging.getLogger(__name__)
         if scheduler_api_version is None:
-            warnings.warn("Chronos >=3.x requires scheduler_api_version set", FutureWarning)
             self._prefix = ''
         else:
             if scheduler_api_version not in SCHEDULER_API_VERSIONS:
-                raise ChronosAPIError('Wrong scheduler_api_version provided')
+                raise ChronosAPIError('scheduler_api_version not supported yet: %s' % scheduler_api_version)
             self._prefix = "/%s" % (scheduler_api_version,)
         self.scheduler_api_version = scheduler_api_version
         self.disable_ssl_certificate_validation = not validate_ssl_certificates


### PR DESCRIPTION
The default api version is 'v1' in this library. If a user is explicitly saying "None" because they are not using chronos 3, then the warning doesn't really make sense.

So I vote we remove the warning for those users who are not using chronos 3.